### PR TITLE
Added decompression memory limit of 1GB

### DIFF
--- a/compress.go
+++ b/compress.go
@@ -5,7 +5,7 @@ package main
 import "github.com/klauspost/compress/zstd"
 
 func Decompress(buf []byte) ([]byte, error) {
-	d, err := zstd.NewReader(nil)
+	d, err := zstd.NewReader(nil, zstd.WithDecoderMaxMemory(1<<30))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Before, Trying to decompress a malicious blueprint could make the program use gigabytes of memory.